### PR TITLE
Add support for RDS Aurora clusters

### DIFF
--- a/inventory.py
+++ b/inventory.py
@@ -205,6 +205,7 @@ if ('storagegateway' in arguments):
 #
 if ('rds' in arguments):
     thread_list.append(awsthread.AWSThread('rds', db.get_rds_inventory, ownerId, profile_name, boto3_config, selected_regions))
+    thread_list.append(awsthread.AWSThread('rds-clusters', db.get_aurora_inventory, ownerId, profile_name, boto3_config, selected_regions))
 
 #
 # ----------------- dynamodb inventory
@@ -519,6 +520,10 @@ for svc in arguments:
             "elasticbeanstalk-environments": config.global_inventory["elasticbeanstalk-environments"],
             "elasticbeanstalk-applications": config.global_inventory["elasticbeanstalk-applications"]
         }
+
+    elif (svc == "rds"):
+        inventory[svc] = config.global_inventory[svc]
+        inventory["rds-clusters"] = config.global_inventory["rds-clusters"]
 
     else:
 

--- a/res/db.py
+++ b/res/db.py
@@ -51,6 +51,42 @@ def get_rds_inventory(oId, profile, boto3_config, selected_regions):
 
 #  ------------------------------------------------------------------------
 #
+#    RDS Aurora
+#
+#  ------------------------------------------------------------------------
+
+def get_aurora_inventory(oId, profile, boto3_config, selected_regions):
+
+    """
+        Returns RDS inventory
+
+        :param oId: ownerId (AWS account)
+        :type oId: string
+        :param profile: configuration profile name used for session
+        :type profile: string
+
+        :return: RDS inventory
+        :rtype: json
+
+        ..note:: http://boto3.readthedocs.io/en/latest/reference/services/rds.html
+
+    """
+
+    return glob.get_inventory(
+        ownerId = oId,
+        profile = profile,
+        boto3_config = boto3_config,
+        selected_regions = selected_regions,
+        aws_service = "rds",
+        aws_region = "all",
+        function_name = "describe_db_clusters",
+        key_get = "DBClusters",
+        pagination = True
+    )
+
+
+#  ------------------------------------------------------------------------
+#
 #    DynamoDB 
 #
 #  ------------------------------------------------------------------------


### PR DESCRIPTION
This adds support for RDS Auora and introduces a new key in in the
inventory results called 'rds-clusters'. The inventory is enabled when
'rds' is selected.

@janiko71 - not sure what your preference on how the results for RDS Aurora clusters is returned. In this initial proposal, they are in a separate "rds-clusters" key in the inventory. Please let me know if you want any tweaks. Thanks for the tool!