### PR TITLE
Fix typo in Batch compute environments key

### DIFF
--- a/res/compute.py
+++ b/res/compute.py
@@ -584,7 +584,7 @@ def get_batch_inventory(oId, profile):
         key_get = "jobQueues"
     )
 
-    inventory['compute-environements'] = glob.get_inventory(
+    inventory['compute-environments'] = glob.get_inventory(
         ownerId = oId,
         profile = profile,
         aws_service = "batch", 


### PR DESCRIPTION
Remove extra 'e'

s/environements/environments